### PR TITLE
Use is-buffer module to reduce bundle size.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var Buffer = require('buffer').Buffer
+var isBuffer = require('is-buffer')
 
 module.exports = function (buf) {
 	// If the buffer is backed by a Uint8Array, a faster version will work
@@ -12,7 +12,7 @@ module.exports = function (buf) {
 		}
 	}
 
-	if (Buffer.isBuffer(buf)) {
+	if (isBuffer(buf)) {
 		// This is the slow version that will work with any Buffer
 		// implementation (even in old browsers)
 		var arrayCopy = new Uint8Array(buf.length)

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
   "devDependencies": {
     "tape": "^4.4.0",
     "zuul": "^3.9.0"
+  },
+  "dependencies": {
+    "is-buffer": "^1.1.1"
   }
 }


### PR DESCRIPTION
Hey there, thanks for writing this module! I’m pretty sensitive about browserify bundle sizes, so I thought I’d point out that you can yield quite a substantial saving by swapping out `Buffer.isBuffer` for [feross/is-buffer](https://github.com/feross/is-buffer) (see below).

``` sh
# Buffer.isBuffer
$ browserify index.js | sizeist
.js 36.06 kB
.min.js 16.9 kB
.min.js.gz 5.19 kB
```

``` sh
# feross/is-buffer
$ browserify index.js | sizeist
.js 1.86 kB
.min.js 1.03 kB
.min.js.gz 496 B
```
