### PR TITLE
Add `files` to `package.json`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "read",
     "only"
   ],
+  "files": ["index.js"],
   "author": "John Hiesey",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
Prevents `.travis.yml`, `.zuul.yml`, and `test.js` from being published to NPM.