### PR TITLE
Modernize

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ when using [the Buffer implementation provided by Browserify](https://www.npmjs.
 ## Usage
 
 ``` js
-var toArrayBuffer = require('to-arraybuffer')
+import toArrayBuffer from 'to-arraybuffer'
 
-var buffer = new Buffer(100)
+const buffer = Buffer.alloc(100)
 // Fill the buffer with some data
 
-var ab = toArrayBuffer(buffer)
+const ab = toArrayBuffer(buffer)
 // `ab` now contains the same data as `buffer`
 ```
 

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ module.exports = buf => {
   if (!ArrayBuffer.isView(buf)) throw new Error('Argument must be a ArrayBufferView')
 
   // If the buffer isn't a subarray, return the underlying ArrayBuffer
-  if (buf.byteOffset === 0 && buf.byteLength === buf.buffer.byteLength) {
+  if (buf.byteLength === buf.buffer.byteLength) {
     return buf.buffer
   }
 

--- a/index.js
+++ b/index.js
@@ -1,27 +1,13 @@
-var Buffer = require('buffer').Buffer
+module.exports = buf => {
+	if (buf instanceof ArrayBuffer) return buf
 
-module.exports = function (buf) {
-	// If the buffer is backed by a Uint8Array, a faster version will work
-	if (buf instanceof Uint8Array) {
-		// If the buffer isn't a subarray, return the underlying ArrayBuffer
-		if (buf.byteOffset === 0 && buf.byteLength === buf.buffer.byteLength) {
-			return buf.buffer
-		} else if (typeof buf.buffer.slice === 'function') {
-			// Otherwise we need to get a proper copy
-			return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)
-		}
+	if (!ArrayBuffer.isView(buf)) throw new Error('Argument must be a ArrayBufferView')
+
+	// If the buffer isn't a subarray, return the underlying ArrayBuffer
+	if (buf.byteOffset === 0 && buf.byteLength === buf.buffer.byteLength) {
+		return buf.buffer
 	}
 
-	if (Buffer.isBuffer(buf)) {
-		// This is the slow version that will work with any Buffer
-		// implementation (even in old browsers)
-		var arrayCopy = new Uint8Array(buf.length)
-		var len = buf.length
-		for (var i = 0; i < len; i++) {
-			arrayCopy[i] = buf[i]
-		}
-		return arrayCopy.buffer
-	} else {
-		throw new Error('Argument must be a Buffer')
-	}
+	// Otherwise we need to get a proper copy
+	return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)
 }

--- a/index.js
+++ b/index.js
@@ -5,10 +5,8 @@ module.exports = buf => {
   if (!ArrayBuffer.isView(buf)) throw new Error('Argument must be a ArrayBufferView')
 
   // If the buffer isn't a subarray, return the underlying ArrayBuffer
-  if (buf.byteLength === buf.buffer.byteLength) {
-    return buf.buffer
-  }
-
-  // Otherwise we need to get a proper copy
-  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)
+	// Otherwise we need to get a proper copy
+  return buf.byteLength === buf.buffer.byteLength
+	  ? buf.buffer
+    : buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)
 }

--- a/index.js
+++ b/index.js
@@ -1,13 +1,13 @@
 module.exports = buf => {
-	if (buf instanceof ArrayBuffer) return buf
+  if (buf instanceof ArrayBuffer) return buf
 
-	if (!ArrayBuffer.isView(buf)) throw new Error('Argument must be a ArrayBufferView')
+  if (!ArrayBuffer.isView(buf)) throw new Error('Argument must be a ArrayBufferView')
 
-	// If the buffer isn't a subarray, return the underlying ArrayBuffer
-	if (buf.byteOffset === 0 && buf.byteLength === buf.buffer.byteLength) {
-		return buf.buffer
-	}
+  // If the buffer isn't a subarray, return the underlying ArrayBuffer
+  if (buf.byteOffset === 0 && buf.byteLength === buf.buffer.byteLength) {
+    return buf.buffer
+  }
 
-	// Otherwise we need to get a proper copy
-	return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)
+  // Otherwise we need to get a proper copy
+  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)
 }

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+/** @param {ArrayBufferView} buf */
 module.exports = buf => {
   if (buf instanceof ArrayBuffer) return buf
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = buf => {
   if (!ArrayBuffer.isView(buf)) throw new Error('Argument must be a ArrayBufferView')
 
   // If the buffer isn't a subarray, return the underlying ArrayBuffer
-	// Otherwise we need to get a proper copy
+  // Otherwise we need to get a proper copy
   return buf.byteLength === buf.buffer.byteLength
 	  ? buf.buffer
     : buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)

--- a/index.js
+++ b/index.js
@@ -7,6 +7,6 @@ module.exports = buf => {
   // If the buffer isn't a subarray, return the underlying ArrayBuffer
   // Otherwise we need to get a proper copy
   return buf.byteLength === buf.buffer.byteLength
-	  ? buf.buffer
+    ? buf.buffer
     : buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "test-browser": "airtap --loopback airtap.local -- test.js",
     "test-browser-local": "airtap --no-instrument --local 8080 -- test.js"
   },
-  "files": ["index.js"],
+  "files": [
+    "index.js"
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/jhiesey/to-arraybuffer.git"
@@ -29,7 +31,7 @@
   },
   "homepage": "https://github.com/jhiesey/to-arraybuffer#readme",
   "devDependencies": {
-    "airtap": "^0.0.5",
-    "tape": "^4.9.0"
+    "airtap": "^3.0.0",
+    "tape": "^5.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test-browser": "airtap --loopback airtap.local -- test.js",
     "test-browser-local": "airtap --no-instrument --local 8080 -- test.js"
   },
+  "files": ["index.js"],
   "repository": {
     "type": "git",
     "url": "git://github.com/jhiesey/to-arraybuffer.git"

--- a/test.js
+++ b/test.js
@@ -14,7 +14,7 @@ function elementsEqual (ab, buffer) {
 }
 
 test('Basic behavior', function (t) {
-	var buf = new Buffer(10)
+	var buf = Buffer.alloc(10)
 	for (var i = 0; i < 10; i++) {
 		buf[i] = i
 	}
@@ -27,7 +27,7 @@ test('Basic behavior', function (t) {
 })
 
 test('Behavior when input is a subarray 1', function (t) {
-	var origBuf = new Buffer(10)
+	var origBuf = Buffer.alloc(10)
 	for (var i = 0; i < 10; i++) {
 		origBuf[i] = i
 	}
@@ -42,7 +42,7 @@ test('Behavior when input is a subarray 1', function (t) {
 })
 
 test('Behavior when input is a subarray 2', function (t) {
-	var origBuf = new Buffer(10)
+	var origBuf = Buffer.alloc(10)
 	for (var i = 0; i < 10; i++) {
 		origBuf[i] = i
 	}

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 const Buffer = require('buffer').Buffer
 const test = require('tape')
 
-const toArrayBuffer = require('.')
+const toArrayBuffer = require('./index.js')
 
 function elementsEqual (ab, buffer) {
   const view = new Uint8Array(ab)

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-const Buffer = require('buffer').Buffer
+const { Buffer } = require('buffer')
 const test = require('tape')
 
 const toArrayBuffer = require('./index.js')

--- a/test.js
+++ b/test.js
@@ -1,57 +1,57 @@
-var Buffer = require('buffer').Buffer
-var test = require('tape')
+const Buffer = require('buffer').Buffer
+const test = require('tape')
 
-var toArrayBuffer = require('.')
+const toArrayBuffer = require('.')
 
 function elementsEqual (ab, buffer) {
-	var view = new Uint8Array(ab)
-	for (var i = 0; i < view.length; i++) {
-		if (view[i] !== buffer[i]) {
-			return false
-		}
-	}
-	return true
+  const view = new Uint8Array(ab)
+  for (let i = 0; i < view.length; i++) {
+    if (view[i] !== buffer[i]) {
+      return false
+    }
+  }
+  return true
 }
 
 test('Basic behavior', function (t) {
-	var buf = Buffer.alloc(10)
-	for (var i = 0; i < 10; i++) {
-		buf[i] = i
-	}
+  const buf = Buffer.alloc(10)
+  for (let i = 0; i < 10; i++) {
+    buf[i] = i
+  }
 
-	var ab = toArrayBuffer(buf)
+  const ab = toArrayBuffer(buf)
 
-	t.equals(ab.byteLength, 10, 'correct length')
-	t.ok(elementsEqual(ab, buf), 'elements equal')
-	t.end()
+  t.equals(ab.byteLength, 10, 'correct length')
+  t.ok(elementsEqual(ab, buf), 'elements equal')
+  t.end()
 })
 
 test('Behavior when input is a subarray 1', function (t) {
-	var origBuf = Buffer.alloc(10)
-	for (var i = 0; i < 10; i++) {
-		origBuf[i] = i
-	}
-	var buf = origBuf.slice(1)
+  const origBuf = Buffer.alloc(10)
+  for (let i = 0; i < 10; i++) {
+    origBuf[i] = i
+  }
+  const buf = origBuf.slice(1)
 
-	var ab = toArrayBuffer(buf)
+  const ab = toArrayBuffer(buf)
 
-	t.equals(ab.byteLength, 9, 'correct length')
-	t.ok(elementsEqual(ab, buf), 'elements equal')
-	t.notOk(ab === buf.buffer, 'the underlying ArrayBuffer is not returned when incorrect')
-	t.end()
+  t.equals(ab.byteLength, 9, 'correct length')
+  t.ok(elementsEqual(ab, buf), 'elements equal')
+  t.notOk(ab === buf.buffer, 'the underlying ArrayBuffer is not returned when incorrect')
+  t.end()
 })
 
 test('Behavior when input is a subarray 2', function (t) {
-	var origBuf = Buffer.alloc(10)
-	for (var i = 0; i < 10; i++) {
-		origBuf[i] = i
-	}
-	var buf = origBuf.slice(0, 9)
+  const origBuf = Buffer.alloc(10)
+  for (let i = 0; i < 10; i++) {
+    origBuf[i] = i
+  }
+  const buf = origBuf.slice(0, 9)
 
-	var ab = toArrayBuffer(buf)
+  const ab = toArrayBuffer(buf)
 
-	t.equals(ab.byteLength, 9, 'correct length')
-	t.ok(elementsEqual(ab, buf), 'elements equal')
-	t.notOk(ab === buf.buffer, 'the underlying ArrayBuffer is not returned when incorrect')
-	t.end()
+  t.equals(ab.byteLength, 9, 'correct length')
+  t.ok(elementsEqual(ab, buf), 'elements equal')
+  t.notOk(ab === buf.buffer, 'the underlying ArrayBuffer is not returned when incorrect')
+  t.end()
 })


### PR DESCRIPTION
This will 
- update the devDep
- it will not embed Buffer into the browser bundle (as they are always uint8array)
- if argument is a arraybuffer, then just return it.
- stop using Buffer constructor in test files
- update the example in readme
- and now it can also return the arraybuffer of any ArrayBuffer view (not just uint8array or buffer)


I would maybe have used `new TextEncoder().encode(whatever).buffer` as a fallback and not thrown on non typed arrays.
Would also like to have switched this to ESM only package
but decided to keep it as it's with as few changes

fixes #1
fixes #2
fixes #3
